### PR TITLE
Fix segmentation fault for time series including NaN values

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 # Template workflow to build and install BiasAdjustCXX
 #

--- a/.github/workflows/_build_doc.yaml
+++ b/.github/workflows/_build_doc.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 # Template workflow to build documentation.
 #

--- a/.github/workflows/_build_docker.yaml
+++ b/.github/workflows/_build_docker.yaml
@@ -1,7 +1,7 @@
 ##    Checks the code logic, style and more
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 # Workflow to build the docker image.
 

--- a/.github/workflows/_pre_commit.yaml
+++ b/.github/workflows/_pre_commit.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 # Template workflow to run pre-commit.
 #

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -1,7 +1,7 @@
 ##    Checks the code logic, style and more
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 # Workflow to build the test suite and run the unit tests.
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,7 +1,7 @@
 ##    Checks the code logic, style and more
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 # Workflow to apply pre-commit, build, test and upload the docker
 # image(s).

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 ##    Checks the code logic, style and more
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 # Workflow to apply pre-commit, build, test and upload the docker
 # image. This job is only triggered during a release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 ##    Checks the code logic, style and more
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 # Workflow to apply pre-commit, build, test and upload the docker
 # image. This job is only triggered during a release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **Merged pull requests:**
 
+- Readme: add table of content; fix wrong section numbering; fix badge [\#30](https://github.com/btschwertfeger/BiasAdjustCXX/pull/30) ([btschwertfeger](https://github.com/btschwertfeger))
+- Add hints for NetCDFcxx not found error; fix typos [\#29](https://github.com/btschwertfeger/BiasAdjustCXX/pull/29) ([btschwertfeger](https://github.com/btschwertfeger))
 - Add release workflow [\#27](https://github.com/btschwertfeger/BiasAdjustCXX/pull/27) ([btschwertfeger](https://github.com/btschwertfeger))
 - Clarified difference between stochastic and non-stochastic climate variables in doc and readme [\#26](https://github.com/btschwertfeger/BiasAdjustCXX/pull/26) ([btschwertfeger](https://github.com/btschwertfeger))
 - Added more checks during testing [\#25](https://github.com/btschwertfeger/BiasAdjustCXX/pull/25) ([btschwertfeger](https://github.com/btschwertfeger))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 project(BiasAdjustCXX
-    VERSION 1.9.0
+    VERSION 1.9.1
     DESCRIPTION "Bias correction command-line tool for NetCDF-based climate data"
     LANGUAGES CXX
 )

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # -*- coding:utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 
 FROM alpine:3.17 AS builder

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!make
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 
 PROJECT := BiasAdjustCXX
 TEST_PROJECT := TestBiasAdjustCXX
@@ -46,12 +46,12 @@ redoc: clean doc
 
 ## ======= U N -/ I N S T A L L A T I O N =======
 ## install	Installation of the BiasAdjustCXX tool
-##		(after a successfull the build)
+##		(after a successful the build)
 ##
 install:
 	cd build && make install
 
-## uninstall	Uninstallation of the BiasAdjustCXX tool
+## uninstall	Remove of the BiasAdjustCXX tool
 ##
 uninstall:
 	cd build && make uninstall
@@ -72,6 +72,8 @@ uninstall-val:
 ##
 test:
 	cd build/tests && ctest
+
+retest: dev test
 
 ## ======= M I S C E L A N I O U S =======
 ## changelog	Create the changelog

--- a/include/Utils.hxx
+++ b/include/Utils.hxx
@@ -30,7 +30,7 @@
 #include <iostream>
 
 namespace utils {
-/** Class to create log files */
+// Class to create log files
 class Log {
    public:
     Log();
@@ -43,6 +43,13 @@ class Log {
 
    private:
 };
+
+// Custom exception for NaN values
+class NaNException : public std::exception {
+   public:
+    const char* what() const noexcept override;
+};
+
 bool isInStrV(std::vector<std::string> v, std::string string);
 void progress_bar(float part, float all);
 std::string get_version();

--- a/src/CMethods.cxx
+++ b/src/CMethods.cxx
@@ -24,9 +24,9 @@
  *
  *
  * * Notes:
- *  - Methods does not have to match the description of the mentioned papers
- *      - some of them are derived and improved
- *      - the references are just the base of the methods
+ *   * Methods does not have to match the description of the mentioned papers
+ *      * some of them are derived and improved
+ *      * the references are just the base of the methods
  */
 
 /**
@@ -44,6 +44,7 @@
 #include <vector>
 
 #include "MathUtils.hxx"
+#include "Utils.hxx"
 #include "math.h"
 
 /**
@@ -52,8 +53,10 @@
  * * ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- -----
  */
 
-std::vector<std::string> CMethods::scaling_method_names = {"linear_scaling", "variance_scaling", "delta_method"};
-std::vector<std::string> CMethods::distribution_method_names = {"quantile_mapping", "quantile_delta_mapping"};
+std::vector<std::string> CMethods::scaling_method_names = {
+    "linear_scaling", "variance_scaling", "delta_method"};
+std::vector<std::string> CMethods::distribution_method_names = {
+    "quantile_mapping", "quantile_delta_mapping"};
 
 /**
  * * ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- -----
@@ -72,10 +75,12 @@ CMethods::~CMethods() {}
 
 /**
  * Get 365 long-term 31-day moving windows
- * When using long-term 31-day intervals, leap years should not be included and every year must be complete.
+ * When using long-term 31-day intervals, leap years should not be included and
+ * every year must be complete.
  *
  * @param v_in input vector containing 365 entries for $n$ years
- * @return 2D vector (dimensions: [365, 31 * y]) containing the values with index -15...0...+15 around a day over all years
+ * @return 2D vector (dimensions: [365, 31 * y]) containing the values with
+ *         index -15...0...+15 around a day over all years
  */
 std::vector<std::vector<float>> CMethods::get_long_term_dayofyear(std::vector<float>& v_in) {
     std::vector<std::vector<float>> v_out(365, std::vector<float>());
@@ -125,7 +130,8 @@ std::vector<std::vector<float>> CMethods::get_long_term_dayofyear(std::vector<fl
  * Checks and returns the desired scaling factor based on `max_factor`
  *
  * @param factor value to check
- * @param max_factor max allowed factor (will be casted to positive value, cannot be zero)
+ * @param max_factor max allowed factor (will be casted to positive value, can't
+ *                   be zero)
  * @return either `factor` if it's ok or `max_factor`
  */
 double CMethods::get_adjusted_scaling_factor(double factor, double max_factor) {
@@ -146,8 +152,9 @@ double CMethods::get_adjusted_scaling_factor(double factor, double max_factor) {
 /**
  * Method to adjust 1-dimensional climate data by the linear scaling method.
  * Based on the equations of Teutschbein, Claudia and Seibert, Jan (2012)
- * Bias correction of regional climate model simulations for hydrological climate-change impact studies:
- * Review and evaluation of different methods (https://doi.org/10.1016/j.jhydrol.2012.05.052)
+ * Bias correction of regional climate model simulations for hydrological
+ * climate-change impact studies: Review and evaluation of different methods
+ * (https://doi.org/10.1016/j.jhydrol.2012.05.052)
  *
  * @param v_output 1D output vector that stores the adjusted time series
  * @param v_reference 1D reference time series (control period)
@@ -232,8 +239,9 @@ void CMethods::Linear_Scaling(
 /**
  * Method to adjust 1 dimensional climate data by variance scaling method.
  * Based on the equations of Teutschbein, Claudia and Seibert, Jan (2012)
- * Bias correction of regional climate model simulations for hydrological climate-change impact studies:
- * Review and evaluation of different methods (https://doi.org/10.1016/j.jhydrol.2012.05.052)
+ * Bias correction of regional climate model simulations for hydrological
+ * climate-change impact studies: Review and evaluation of different methods
+ * (https://doi.org/10.1016/j.jhydrol.2012.05.052)
  *
  * @param v_output 1D output vector that stores the adjusted time series
  * @param v_reference 1D reference time series (control period)
@@ -340,8 +348,9 @@ void CMethods::Variance_Scaling(
 
 /**
  * Method to adjust 1-dimensional climate data by the delta method.
- * Based on Beyer, R. and Krapp, M. and Manica, A.: An empirical evaluation of bias
- * correction methods for paleoclimate simulations (https://doi.org/10.5194/cp-16-1493-2020)
+ * Based on Beyer, R. and Krapp, M. and Manica, A.: An empirical evaluation of
+ * bias correction methods for paleoclimate simulations
+ * (https://doi.org/10.5194/cp-16-1493-2020)
  *
  * NOTE: `v_reference.size()` must be equal to `v_scenario.size()`
  * @param v_output 1D output vector that stores the adjusted time series
@@ -470,14 +479,16 @@ bool is_larger(double a, double b) {
 
 /**
  * Returns the probability boundaries based on two input time series
- * -> This is required to compute the bin boundaries for the Probability Density and Cumulative Distribution Function.
- * -> Used by Quantile and Quantile Delta Mapping by invoking this function to get the bins based on the time
- *    series of the control period.
+ * -> This is required to compute the bin boundaries for the Probability Density
+ *    and Cumulative Distribution Function.
+ * -> Used by Quantile and Quantile Delta Mapping by invoking this function to
+ *    get the bins based on the time series of the control period.
  *
  * @param a time series
  * @param b another time series
  * @param n_quantiles number of quantiles to use/respect
- * @param kind regular or bounded: defines if minimum value of a (climate) variable can be lower than in the data
+ * @param kind regular or bounded: defines if minimum value of a (climate)
+ *             variable can be lower than in the data
  *             or is set to 0 (ratio based variables => 0)
  * @return the probability boundaries mentioned above
  */
@@ -494,6 +505,16 @@ std::vector<double> CMethods::get_xbins(
             b_max = *std::max_element(b.begin(), b.end(), is_smaller),
             b_min = *std::min_element(b.begin(), b.end(), is_larger);
 
+        // check if probability boundaries can be determined
+        // clang-format off
+        if (
+               std::isnan(a_max) || std::isnan(b_max)
+            || std::isnan(a_min) || std::isnan(b_min)
+            || a_max == b_max    || a_min == b_min
+        )
+            throw utils::NaNException();
+         // clang-format off
+
         const double
             global_max = std::max(a_max, b_max),
             global_min = std::min(a_min, b_min);
@@ -509,6 +530,11 @@ std::vector<double> CMethods::get_xbins(
         const double
             a_max = *std::max_element(std::begin(a), std::end(a), is_smaller),
             b_max = *std::max_element(std::begin(b), std::end(b), is_smaller);
+
+        // check if probability boundaries can be determined
+        if (std::isnan(a_max) or std::isnan(b_max) || a_max == b_max)
+            throw utils::NaNException();
+
         const double global_max = std::max(a_max, b_max);
         const double wide = global_max / n_quantiles;
 
@@ -526,8 +552,9 @@ std::vector<double> CMethods::get_xbins(
 
 /**
  * Quantile Mapping bias correction based on
- * Tong, Y., Gao, X., Han, Z. et al. Bias correction of temperature and precipitation over China for RCM
- * simulations using the QM and QDM methods. Clim Dyn 57, 1425–1443 (2021). https://doi.org/10.1007/s00382-020-05447-4
+ * Tong, Y., Gao, X., Han, Z. et al. Bias correction of temperature and
+ * precipitation over China for RCM simulations using the QM and QDM methods.
+ * Clim Dyn 57, 1425–1443 (2021). https://doi.org/10.1007/s00382-020-05447-4
  *
  * @param v_output 1D output vector that stores the adjusted time series
  * @param v_reference 1D reference time series (control period)
@@ -553,15 +580,28 @@ void CMethods::Quantile_Mapping(
 ) {
     const bool isAdd = (settings.kind == "add" || settings.kind == "+") ? true : false;
     if (!isAdd && !(settings.kind == "mult" || settings.kind == "*"))
-        throw std::runtime_error("Adjustment kind " + settings.kind + " unknown for quantile mapping!");
+        throw("Adjustment kind " + settings.kind + " unknown for quantile mapping!");
 
-    std::vector<double>
+    // -------------------------------------------------------------------------
+    // If the xbins / probability boundaries can't be determined, because
+    // at least one of the time series only consists of nan values
+    // just return the uncorrected scenario time series.
+
+    std::vector<double> v_xbins;
+    try {
         v_xbins = get_xbins(
             v_reference,
             v_control,
             settings.n_quantiles,
             (isAdd) ? "regular" : "bounded"
         );
+    } catch (const utils::NaNException& e) {
+        for (unsigned ts = 0; ts < v_scenario.size(); ts++)
+            v_output[ts] = v_scenario[ts];
+        return;
+    }
+
+    // -------------------------------------------------------------------------
 
     std::vector<int>  // ? create CDFs
         vi_ref_cdf = MathUtils::get_cdf(v_reference, v_xbins),
@@ -598,8 +638,9 @@ void CMethods::Quantile_Mapping(
 
 /**
  * Quantile Delta Mapping bias correction based on
- * Tong, Y., Gao, X., Han, Z. et al. Bias correction of temperature and precipitation over China for RCM
- * simulations using the QM and QDM methods. Clim Dyn 57, 1425–1443 (2021). https://doi.org/10.1007/s00382-020-05447-4
+ * Tong, Y., Gao, X., Han, Z. et al. Bias correction of temperature and
+ * precipitation over China for RCM simulations using the QM and QDM methods.
+ * Clim Dyn 57, 1425–1443 (2021). https://doi.org/10.1007/s00382-020-05447-4
  *
  * @param v_output 1D output vector that stores the adjusted time series
  * @param v_reference 1D reference time series (control period)
@@ -636,13 +677,26 @@ void CMethods::Quantile_Delta_Mapping(
     if (!isAdd && !(settings.kind == "mult" || settings.kind == "*"))
         throw std::runtime_error("Adjustment kind " + settings.kind + " unknown for quantile delta mapping!");
 
-    std::vector<double>
+    // -------------------------------------------------------------------------
+    // If the xbins / probability boundaries can't be determined, because
+    // at least one of the time series only consists of nan values
+    // just return the uncorrected scenario time series.
+
+    std::vector<double> v_xbins;
+    try {
         v_xbins = get_xbins(
             v_reference,
             v_control,
             settings.n_quantiles,
             (isAdd) ? "regular" : "bounded"
         );
+    } catch (const utils::NaNException& e) {
+        for (unsigned ts = 0; ts < v_scenario.size(); ts++)
+            v_output[ts] = v_scenario[ts];
+        return;
+    }
+
+    // -------------------------------------------------------------------------
 
     // ? create CDF
     std::vector<int>
@@ -673,7 +727,6 @@ void CMethods::Quantile_Delta_Mapping(
     } else {
         // clang-format off
         for (unsigned ts = 0; ts < v_scenario.size(); ts++) {
-
             v_output[ts] = QDM1[ts] * MathUtils::ensure_devidable(
                 (double) v_scenario[ts],
                 MathUtils::interpolate(contr_cdf, v_xbins, epsilon[ts], false),

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -79,7 +79,7 @@ void progress_bar(float part, float all) {
 namespace utils {
 
 std::string get_version() {
-    return "v1.9.0";
+    return "v1.9.1";
 }
 
 void show_copyright_notice(std::string program_name) {

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -33,6 +33,9 @@
 #include "colors.h"
 
 namespace utils {
+
+// -----------------------------------------------------------------------------
+// LOGGING
 utils::Log::Log() {}
 utils::Log::~Log() {}
 
@@ -41,14 +44,14 @@ void utils::Log::info(std::string message) { std::cout << GREEN << "INFO: " << R
 void utils::Log::warning(std::string message) { std::cout << YELLOW << "WARNING: " << RESET << message << std::endl; }
 void utils::Log::error(std::string message) { std::cout << BOLDRED << "ERROR: " << RESET << message << std::endl; }
 
+// -----------------------------------------------------------------------------
+// EXCEPTIONS
 const char* utils::NaNException::what() const noexcept {
     return "Value is NaN!";
 };
 
-}  // namespace utils
-
-namespace utils {
-
+// -----------------------------------------------------------------------------
+// UTILITY FUNCTIONS
 bool isInStrV(std::vector<std::string> v, std::string string) {
     if (std::find(v.begin(), v.end(), string) != v.end())
         return true;
@@ -78,10 +81,6 @@ void progress_bar(float part, float all) {
     std::cout << " ] " << int(progress * 100.0) << " %\r";
     std::cout.flush();
 }
-
-}  // namespace utils
-
-namespace utils {
 
 std::string get_version() {
     return "v1.9.1";

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -40,15 +40,14 @@ void utils::Log::debug(std::string message) { std::cout << WHITE << "DEBUG: " <<
 void utils::Log::info(std::string message) { std::cout << GREEN << "INFO: " << RESET << message << std::endl; }
 void utils::Log::warning(std::string message) { std::cout << YELLOW << "WARNING: " << RESET << message << std::endl; }
 void utils::Log::error(std::string message) { std::cout << BOLDRED << "ERROR: " << RESET << message << std::endl; }
+
+const char* utils::NaNException::what() const noexcept {
+    return "Value is NaN!";
+};
+
 }  // namespace utils
 
 namespace utils {
-/** Progress bar to bar the progress
- *  inspired by: https://stackoverflow.com/a/14539953/13618168
- *
- * @param part fraction of the process that is done
- * @param all total number of processes
- */
 
 bool isInStrV(std::vector<std::string> v, std::string string) {
     if (std::find(v.begin(), v.end(), string) != v.end())
@@ -56,6 +55,12 @@ bool isInStrV(std::vector<std::string> v, std::string string) {
     else
         return false;
 }
+/** Progress bar to bar the progress
+ *  inspired by: https://stackoverflow.com/a/14539953/13618168
+ *
+ * @param part fraction of the process that is done
+ * @param all total number of processes
+ */
 void progress_bar(float part, float all) {
     const float progress = part / all;
     const unsigned barWidth = 70;


### PR DESCRIPTION
# Summary

To avoid segmentation faults when having time series containing nan values, some more checks were added. This only occurred for distribution based methods.

If the observation data or the time series of the control period contains nans, these get ignored - if one of the time series only includes nan values, there can't be made an adjustment and the scenario time series is returned instead. 