### PR TITLE
Resolve "The -v option is used twice, for `--variable` and `--version`"

### DIFF
--- a/examples/example_all_methods.run.sh
+++ b/examples/example_all_methods.run.sh
@@ -45,7 +45,7 @@ variable="tas"
 kind="+"
 n_quantiles=100
 
-exec_file="${work_dir}/../build/BiasAdjustCXX"
+exec_file="${work_dir}/../build/src/BiasAdjustCXX"
 
 declare -a month_methods=("delta_method" "linear_scaling" "variance_scaling")
 declare -a quant_methods=("quantile_mapping" "quantile_delta_mapping")
@@ -72,7 +72,7 @@ declare -a datasets=("${observations}" "${control}" "${scenario}")
 declare -a ds_paths=("${tmp_ref}" "${tmp_contr}" "${tmp_scen}")
 
 # * -------------------------------------------------------------------
-# *            ===== Distribution-based Adjustent =====
+# *            ===== Distribution-based Adjustment =====
 # * -------------------------------------------------------------------
 
 for method in "${quant_methods[@]}"; do
@@ -91,7 +91,7 @@ done
 
 
 # * -------------------------------------------------------------------
-# *  ===== Default Scaling Adjustent (long-term 31-day intervals) =====
+# *  === Default Scaling Adjustment (long-term 31-day intervals) ===
 # * -------------------------------------------------------------------
 
 # ? Additive linear scaling based on 31 day long-term mean interval instead of

--- a/src/Manager.cxx
+++ b/src/Manager.cxx
@@ -163,7 +163,7 @@ void Manager::parse_args() {
 
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
-        if (arg == "-v" || arg == "--version") {
+        if (arg == "--version") {
             std::cout << utils::get_version() << std::endl;
             exit(0);
         } else if (arg == "--ref" || arg == "--reference") {

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -83,7 +83,7 @@ void progress_bar(float part, float all) {
 }
 
 std::string get_version() {
-    return "v1.9.1";
+    return "v1.9.3";
 }
 
 void show_copyright_notice(std::string program_name) {


### PR DESCRIPTION
Removing the -v option from the list of options to print the version is the way to go.